### PR TITLE
Update README.md to correct broken zotxt-emacs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ For example:
 
 ## emacs integration
 
-See [zotxt-emacs](https://github.com/egh/emacs-zotxt]
-
+    See [zotxt-emacs](https://github.com/egh/zotxt-emacs)
 Zotxt API
 ---------
 


### PR DESCRIPTION
The link to the zotxt-emacs repository was broken. This patch puts the correct link in.