### PR TITLE
Fix: README.md zotxt-emacs Link Markdown Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ For example:
 
 ## emacs integration
 
-    See [zotxt-emacs](https://github.com/egh/zotxt-emacs)
+See [zotxt-emacs](https://github.com/egh/zotxt-emacs)
+
 Zotxt API
 ---------
 


### PR DESCRIPTION
This PR fixes the zotxt-emacs typo and displays the link properly.